### PR TITLE
Fix README typo

### DIFF
--- a/pytorch/README.md
+++ b/pytorch/README.md
@@ -37,7 +37,7 @@ computer-vision-services/
 |   ├── Dockerfile           # Dockerfile for building the service
 |   ├── infer.py             # Image and Video pre & post process for inference
 |   ├── main.py              # Main script for inference
-|   ├── utils.py             # Utlity functions
+|   ├── utils.py             # Utility functions.
 |   ├── myenv.yml            # Python Conda env file
 |   ├── data_input/          # Sample input data
 |   │   ├── images/          # Place your images here


### PR DESCRIPTION
## Summary
- fix typo for utils description in PyTorch README

## Testing
- `python -m compileall -q pytorch`