### PR TITLE
Add semantic segmentation support

### DIFF
--- a/pytorch/README.md
+++ b/pytorch/README.md
@@ -47,11 +47,12 @@ computer-vision-services/
 
 ### **4. Configuration**
 
-Edit the `config.yaml` file to specify input and output directories, model name, detection thresholds, and supported class labels:
+Edit the `config.yaml` file to specify the task, input and output directories, model name, detection thresholds, and supported class labels:
 ```yaml
 input_dir: "data_input/images"       # Path to input images/videos
 output_dir: "infer_output"     # Path to save annotated outputs
-model_name: "fasterrcnn_resnet50_fpn"  # Object detection model
+task: "object_detection"               # or semantic_segmentation
+model_name: "fasterrcnn_resnet50_fpn"  # Model name
 threshold: 0.5                # Confidence threshold for predictions
 coco_labels:             # Labels to include in the output
   - person

--- a/pytorch/config.yaml
+++ b/pytorch/config.yaml
@@ -1,5 +1,6 @@
 input_dir: "data_input/videos/"           # Directory for input images/videos
 output_dir: "infer_output/"         # Directory to save annotated outputs
+task: "object_detection"            # image_classification|object_detection|semantic_segmentation|keypoint_detection
 model_name: "fcos_resnet50_fpn"  # Model name for object detection
 model_weights_class: "FCOS_ResNet50_FPN_Weights"
 model_weights: "COCO_V1"

--- a/pytorch/configs/config.yaml
+++ b/pytorch/configs/config.yaml
@@ -1,5 +1,6 @@
 input_dir: "data_input/videos/"           # Directory for input images/videos
 output_dir: "infer_output/"         # Directory to save annotated outputs
+task: "object_detection"            # image_classification|object_detection|semantic_segmentation|keypoint_detection
 model_name: "fcos_resnet50_fpn"  # Model name for object detection
 model_weights_class: "FCOS_ResNet50_FPN_Weights"
 model_weights: "COCO_V1"

--- a/pytorch/infer.py
+++ b/pytorch/infer.py
@@ -118,3 +118,71 @@ def process_video(video_path, model, device, labels, palette, infer_output_dir, 
     print(f"Annotated video saved to {output_path}")
 
 
+def predict_segmentation(model, device, image_tensor):
+    image_tensor = image_tensor.to(device)
+    with torch.no_grad():
+        output = model(image_tensor)
+        if isinstance(output, dict) and "out" in output:
+            output = output["out"]
+    return output[0]
+
+
+def annotate_segmentation(image, output, labels, palette, alpha=0.6):
+    class_map = output.argmax(0).byte().cpu().numpy()
+    color_mask = np.zeros((class_map.shape[0], class_map.shape[1], 3), dtype=np.uint8)
+    for idx, label in enumerate(labels):
+        mask = class_map == idx
+        color_mask[mask] = palette.get(label, (255, 255, 255))
+    mask_image = Image.fromarray(color_mask)
+    image = image.convert("RGBA")
+    mask_image = mask_image.convert("RGBA")
+    return Image.blend(image, mask_image, alpha)
+
+
+def process_image_segmentation(image_path, model, device, labels, palette):
+    try:
+        image = Image.open(image_path).convert("RGB")
+    except (FileNotFoundError, OSError) as e:
+        print(f"Error opening image {image_path}: {e}")
+        return None
+
+    input_tensor = transform(image).unsqueeze(0)
+    output = predict_segmentation(model, device, input_tensor)
+    return annotate_segmentation(image, output, labels, palette)
+
+
+def process_video_segmentation(video_path, model, device, labels, palette, infer_output_dir, fps=30):
+    output_path = os.path.join(infer_output_dir, f"annotated_{os.path.basename(video_path)}")
+    os.makedirs(infer_output_dir, exist_ok=True)
+    cap = cv2.VideoCapture(video_path)
+    if not cap.isOpened():
+        print(f"Error opening video file {video_path}")
+        return
+
+    frame_width = int(cap.get(cv2.CAP_PROP_FRAME_WIDTH))
+    frame_height = int(cap.get(cv2.CAP_PROP_FRAME_HEIGHT))
+    input_fps = cap.get(cv2.CAP_PROP_FPS)
+    fps = input_fps if fps is None else fps
+
+    fourcc = cv2.VideoWriter_fourcc(*"mp4v")
+    out = cv2.VideoWriter(output_path, fourcc, fps, (frame_width, frame_height))
+    frame_count = int(cap.get(cv2.CAP_PROP_FRAME_COUNT))
+    for _ in tqdm(range(frame_count), desc="Processing frames", colour="green"):
+        ret, frame = cap.read()
+        if not ret:
+            break
+
+        frame_rgb = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
+        frame_image = Image.fromarray(frame_rgb)
+        input_tensor = transform(frame_image).unsqueeze(0)
+        output = predict_segmentation(model, device, input_tensor)
+        annotated_image = annotate_segmentation(frame_image, output, labels, palette)
+        annotated_frame = np.array(annotated_image.convert("RGB"))
+        annotated_frame_bgr = cv2.cvtColor(annotated_frame, cv2.COLOR_RGB2BGR)
+        out.write(annotated_frame_bgr)
+
+    cap.release()
+    out.release()
+    print(f"Annotated video saved to {output_path}")
+
+


### PR DESCRIPTION
## Summary
- extend configuration with `task` parameter to select CV task
- support semantic segmentation models in `infer.py` and `main.py`
- document new `task` config option in README

## Testing
- `python -m py_compile pytorch/infer.py pytorch/main.py`
