### PR TITLE
Add image classification task support

### DIFF
--- a/pytorch/README.md
+++ b/pytorch/README.md
@@ -2,7 +2,7 @@
 
 A streamlined service to **run and test image classification, object detection, semantic segmentation, and keypoint detection models** available in TorchVision's model zoo. This GPU-enabled service leverages PyTorch and TorchVision to deliver efficient inference for a variety of computer vision tasks on both images and videos.
 
-NOTE: This version currently supports *Object Detection* models.
+NOTE: This version currently supports *Object Detection* and *Image Classification* models.
 ---
 
 ## **Features**
@@ -51,7 +51,7 @@ Edit the `config.yaml` file to specify the task, input and output directories, m
 ```yaml
 input_dir: "data_input/images"       # Path to input images/videos
 output_dir: "infer_output"     # Path to save annotated outputs
-task: "object_detection"               # or semantic_segmentation
+task: "object_detection"               # image_classification|semantic_segmentation
 model_name: "fasterrcnn_resnet50_fpn"  # Model name
 threshold: 0.5                # Confidence threshold for predictions
 coco_labels:             # Labels to include in the output


### PR DESCRIPTION
## Summary
- extend infer.py with transforms and functions for classification
- support classification task selection in main.py

## Testing
- `python -m py_compile pytorch/infer.py pytorch/main.py`
- `python pytorch/main.py` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_685238458c548326be52f84357c30075