### PR TITLE
Add tests and test-report infrastructure

### DIFF
--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -e
+
+export PYTHONPATH="$(pwd)/pytorch:${PYTHONPATH}"
+
+# append header with timestamp
+echo "## $(date)" >> test-report.md
+pytest --cov=pytorch --cov-report=term "$@" 2>&1 | tee -a test-report.md

--- a/test-report.md
+++ b/test-report.md
@@ -1,0 +1,128 @@
+## Wed Jun 18 09:08:29 UTC 2025
+ERROR: usage: pytest [options] [file_or_dir] [file_or_dir] [...]
+pytest: error: unrecognized arguments: --cov=pytorch --cov-report=term
+  inifile: None
+  rootdir: /workspace/computer-vision-services
+
+## Wed Jun 18 09:08:36 UTC 2025
+
+==================================== ERRORS ====================================
+____________________ ERROR collecting tests/test_config.py _____________________
+ImportError while importing test module '/workspace/computer-vision-services/tests/test_config.py'.
+Hint: make sure your test modules/packages have valid Python names.
+Traceback:
+/root/.pyenv/versions/3.11.12/lib/python3.11/importlib/__init__.py:126: in import_module
+    return _bootstrap._gcd_import(name[level:], package, level)
+tests/test_config.py:1: in <module>
+    import yaml
+E   ModuleNotFoundError: No module named 'yaml'
+_____________________ ERROR collecting tests/test_infer.py _____________________
+ImportError while importing test module '/workspace/computer-vision-services/tests/test_infer.py'.
+Hint: make sure your test modules/packages have valid Python names.
+Traceback:
+/root/.pyenv/versions/3.11.12/lib/python3.11/importlib/__init__.py:126: in import_module
+    return _bootstrap._gcd_import(name[level:], package, level)
+tests/test_infer.py:3: in <module>
+    from pytorch.infer import process_image, process_image_segmentation, process_image_classification
+E   ModuleNotFoundError: No module named 'pytorch'
+_____________________ ERROR collecting tests/test_utils.py _____________________
+ImportError while importing test module '/workspace/computer-vision-services/tests/test_utils.py'.
+Hint: make sure your test modules/packages have valid Python names.
+Traceback:
+/root/.pyenv/versions/3.11.12/lib/python3.11/importlib/__init__.py:126: in import_module
+    return _bootstrap._gcd_import(name[level:], package, level)
+tests/test_utils.py:2: in <module>
+    from pytorch.utils import generate_color_palette
+E   ModuleNotFoundError: No module named 'pytorch'
+=========================== short test summary info ============================
+ERROR tests/test_config.py
+ERROR tests/test_infer.py
+ERROR tests/test_utils.py
+!!!!!!!!!!!!!!!!!!! Interrupted: 3 errors during collection !!!!!!!!!!!!!!!!!!!!
+3 errors in 1.68s
+## Wed Jun 18 09:08:45 UTC 2025
+
+==================================== ERRORS ====================================
+____________________ ERROR collecting tests/test_config.py _____________________
+ImportError while importing test module '/workspace/computer-vision-services/tests/test_config.py'.
+Hint: make sure your test modules/packages have valid Python names.
+Traceback:
+/root/.pyenv/versions/3.11.12/lib/python3.11/importlib/__init__.py:126: in import_module
+    return _bootstrap._gcd_import(name[level:], package, level)
+tests/test_config.py:2: in <module>
+    from pytorch.main import load_config
+E   ModuleNotFoundError: No module named 'pytorch'
+_____________________ ERROR collecting tests/test_infer.py _____________________
+ImportError while importing test module '/workspace/computer-vision-services/tests/test_infer.py'.
+Hint: make sure your test modules/packages have valid Python names.
+Traceback:
+/root/.pyenv/versions/3.11.12/lib/python3.11/importlib/__init__.py:126: in import_module
+    return _bootstrap._gcd_import(name[level:], package, level)
+tests/test_infer.py:3: in <module>
+    from pytorch.infer import process_image, process_image_segmentation, process_image_classification
+E   ModuleNotFoundError: No module named 'pytorch'
+_____________________ ERROR collecting tests/test_utils.py _____________________
+ImportError while importing test module '/workspace/computer-vision-services/tests/test_utils.py'.
+Hint: make sure your test modules/packages have valid Python names.
+Traceback:
+/root/.pyenv/versions/3.11.12/lib/python3.11/importlib/__init__.py:126: in import_module
+    return _bootstrap._gcd_import(name[level:], package, level)
+tests/test_utils.py:2: in <module>
+    from pytorch.utils import generate_color_palette
+E   ModuleNotFoundError: No module named 'pytorch'
+=========================== short test summary info ============================
+ERROR tests/test_config.py
+ERROR tests/test_infer.py
+ERROR tests/test_utils.py
+!!!!!!!!!!!!!!!!!!! Interrupted: 3 errors during collection !!!!!!!!!!!!!!!!!!!!
+3 errors in 1.64s
+## Wed Jun 18 09:09:17 UTC 2025
+
+==================================== ERRORS ====================================
+____________________ ERROR collecting tests/test_config.py _____________________
+ImportError while importing test module '/workspace/computer-vision-services/tests/test_config.py'.
+Hint: make sure your test modules/packages have valid Python names.
+Traceback:
+/root/.pyenv/versions/3.11.12/lib/python3.11/importlib/__init__.py:126: in import_module
+    return _bootstrap._gcd_import(name[level:], package, level)
+tests/test_config.py:2: in <module>
+    from pytorch.main import load_config
+E   ModuleNotFoundError: No module named 'pytorch'
+_____________________ ERROR collecting tests/test_infer.py _____________________
+ImportError while importing test module '/workspace/computer-vision-services/tests/test_infer.py'.
+Hint: make sure your test modules/packages have valid Python names.
+Traceback:
+/root/.pyenv/versions/3.11.12/lib/python3.11/importlib/__init__.py:126: in import_module
+    return _bootstrap._gcd_import(name[level:], package, level)
+tests/test_infer.py:3: in <module>
+    from pytorch.infer import process_image, process_image_segmentation, process_image_classification
+E   ModuleNotFoundError: No module named 'pytorch'
+_____________________ ERROR collecting tests/test_utils.py _____________________
+ImportError while importing test module '/workspace/computer-vision-services/tests/test_utils.py'.
+Hint: make sure your test modules/packages have valid Python names.
+Traceback:
+/root/.pyenv/versions/3.11.12/lib/python3.11/importlib/__init__.py:126: in import_module
+    return _bootstrap._gcd_import(name[level:], package, level)
+tests/test_utils.py:2: in <module>
+    from pytorch.utils import generate_color_palette
+E   ModuleNotFoundError: No module named 'pytorch'
+=========================== short test summary info ============================
+ERROR tests/test_config.py
+ERROR tests/test_infer.py
+ERROR tests/test_utils.py
+!!!!!!!!!!!!!!!!!!! Interrupted: 3 errors during collection !!!!!!!!!!!!!!!!!!!!
+3 errors in 1.75s
+## Wed Jun 18 09:09:39 UTC 2025
+.....                                                                    [100%]
+================================ tests coverage ================================
+_______________ coverage: platform linux, python 3.11.12-final-0 _______________
+
+Name                  Stmts   Miss  Cover
+-----------------------------------------
+pytorch/__init__.py       0      0   100%
+pytorch/infer.py        178     98    45%
+pytorch/main.py          71     58    18%
+pytorch/utils.py          6      0   100%
+-----------------------------------------
+TOTAL                   255    156    39%
+5 passed in 3.20s

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,12 @@
+import yaml
+from pytorch.main import load_config
+
+def test_load_config(tmp_path):
+    data = {
+        'model_name': 'm',
+        'model_weights_class': 'c',
+        'model_weights': 'w'
+    }
+    path = tmp_path / 'config.yaml'
+    path.write_text(yaml.safe_dump(data))
+    assert load_config(str(path)) == data

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -1,0 +1,51 @@
+from PIL import Image
+import torch
+from pytorch.infer import process_image, process_image_segmentation, process_image_classification
+from pytorch.utils import generate_color_palette
+
+class DummyDetectionModel:
+    def __call__(self, x):
+        return [{
+            'boxes': torch.tensor([[0, 0, 5, 5]], dtype=torch.float32),
+            'labels': torch.tensor([1]),
+            'scores': torch.tensor([0.9])
+        }]
+
+class DummySegmentationModel:
+    def __call__(self, x):
+        # Return dictionary with 'out' tensor having shape (1, classes, H, W)
+        return {'out': torch.zeros((1, 2, 10, 10))}
+
+class DummyClassificationModel:
+    def __call__(self, x):
+        return torch.tensor([[0.1, 0.9]])
+
+
+def create_test_image(path):
+    Image.new('RGB', (10, 10), color='white').save(path)
+
+
+def test_process_image_detection(tmp_path):
+    img_path = tmp_path / 'img.jpg'
+    create_test_image(img_path)
+    labels = ['obj']
+    palette = generate_color_palette(labels)
+    out_img = process_image(str(img_path), DummyDetectionModel(), torch.device('cpu'), labels, palette)
+    assert isinstance(out_img, Image.Image)
+
+
+def test_process_image_segmentation(tmp_path):
+    img_path = tmp_path / 'img.jpg'
+    create_test_image(img_path)
+    labels = ['bg', 'fg']
+    palette = generate_color_palette(labels)
+    out_img = process_image_segmentation(str(img_path), DummySegmentationModel(), torch.device('cpu'), labels, palette)
+    assert isinstance(out_img, Image.Image)
+
+
+def test_process_image_classification(tmp_path):
+    img_path = tmp_path / 'img.jpg'
+    create_test_image(img_path)
+    labels = ['cat', 'dog']
+    out_img = process_image_classification(str(img_path), DummyClassificationModel(), torch.device('cpu'), labels)
+    assert isinstance(out_img, Image.Image)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,12 @@
+import pytest
+from pytorch.utils import generate_color_palette
+
+
+def test_generate_color_palette():
+    labels = ['cat', 'dog']
+    palette = generate_color_palette(labels)
+    # Should include original labels and an 'unknown' key
+    assert set(palette.keys()) == set(labels + ['unknown'])
+    for color in palette.values():
+        assert isinstance(color, tuple) and len(color) == 3
+        assert all(0 <= c <= 255 for c in color)


### PR DESCRIPTION
## Summary
- add `tests/` directory with unit tests for utility, config loader, and inference functions
- make `pytorch` a package so tests can import modules
- provide `run_tests.sh` script that appends pytest results to `test-report.md`

## Testing
- `./run_tests.sh -q`

------
https://chatgpt.com/codex/tasks/task_e_685281a1d7308326aa48f86f063ae7e3